### PR TITLE
v2.1.1: multi-arch Docker build (amd64 + arm64)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 token.json
 credentials.json
 src/logs
+gcloud-runner.sh

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -14,6 +14,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -22,6 +25,6 @@ jobs:
         with:
           context: .
           push: false
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -8,10 +8,13 @@ jobs:
   push:
     runs-on: ubuntu-latest
     environment: docker hub
-    
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -36,7 +39,7 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,5 @@ cython_debug/
 token.json
 credentials.json
 src/logs
+gcloud-runner.sh
+    

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,23 @@
 FROM python:3.13 AS base
+
+ARG TARGETARCH
+
 RUN apt-get update && apt-get install -y \
     vim \
     cron \
     wget \
     gnupg2 \
-    && mkdir -p /usr/share/keyrings \
-    && wget -q -O - https://dl.google.com/linux/linux_signing_key.pub \
-       | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg \
-    && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] https://dl.google.com/linux/chrome/deb/ stable main" \
-       > /etc/apt/sources.list.d/google-chrome.list \
-    && apt-get update \
-    && apt-get install -y google-chrome-stable \
+    && if [ "$TARGETARCH" = "amd64" ]; then \
+         mkdir -p /usr/share/keyrings \
+         && wget -q -O - https://dl.google.com/linux/linux_signing_key.pub \
+            | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg \
+         && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] https://dl.google.com/linux/chrome/deb/ stable main" \
+            > /etc/apt/sources.list.d/google-chrome.list \
+         && apt-get update \
+         && apt-get install -y google-chrome-stable; \
+       elif [ "$TARGETARCH" = "arm64" ]; then \
+         apt-get install -y chromium; \
+       fi \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,16 @@
 
 mkdir -p /app/logs
 
-printenv | grep -E "^(GAKKO_USERNAME|GAKKO_PASSWORD|GAKKO_CLIENT_ID|PYTHONPATH)=" >> /etc/environment
+# Auto-detect Chrome/Chromium binary for arm64 compatibility
+if [ -z "$GAKKO_CHROME_BINARY_PATH" ]; then
+  if command -v google-chrome-stable >/dev/null 2>&1; then
+    export GAKKO_CHROME_BINARY_PATH="$(command -v google-chrome-stable)"
+  elif command -v chromium >/dev/null 2>&1; then
+    export GAKKO_CHROME_BINARY_PATH="$(command -v chromium)"
+  fi
+fi
+
+printenv | grep -E "^(GAKKO_USERNAME|GAKKO_PASSWORD|GAKKO_CLIENT_ID|GAKKO_CHROME_BINARY_PATH|PYTHONPATH)=" >> /etc/environment
 
 cat <<EOF > /etc/cron.d/gakko-sync
 SHELL=/bin/bash


### PR DESCRIPTION
## Summary
- Add Docker build/publish CI workflows with Docker Hub integration
- Add multi-arch support (amd64 + arm64) with QEMU cross-compilation
- Conditionally install Google Chrome (amd64) or Chromium (arm64) in Dockerfile
- Auto-detect browser binary path in entrypoint.sh for arm64 compatibility

## Test plan
- [ ] Verify `docker buildx build --platform linux/amd64` succeeds
- [ ] Verify `docker buildx build --platform linux/arm64` succeeds
- [ ] Confirm entrypoint auto-detects correct browser binary on each arch