### PR TITLE
v2.1.2: fix Selenium on arm64 — bypass Selenium Manager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y \
          && apt-get update \
          && apt-get install -y google-chrome-stable; \
        elif [ "$TARGETARCH" = "arm64" ]; then \
-         apt-get install -y chromium; \
+         apt-get install -y chromium chromium-driver; \
        fi \
     && rm -rf /var/lib/apt/lists/*
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 mkdir -p /app/logs
 
-# Auto-detect Chrome/Chromium binary for arm64 compatibility
+# Auto-detect Chrome/Chromium binary and driver for arm64 compatibility
 if [ -z "$GAKKO_CHROME_BINARY_PATH" ]; then
   if command -v google-chrome-stable >/dev/null 2>&1; then
     export GAKKO_CHROME_BINARY_PATH="$(command -v google-chrome-stable)"
@@ -11,7 +11,13 @@ if [ -z "$GAKKO_CHROME_BINARY_PATH" ]; then
   fi
 fi
 
-printenv | grep -E "^(GAKKO_USERNAME|GAKKO_PASSWORD|GAKKO_CLIENT_ID|GAKKO_CHROME_BINARY_PATH|PYTHONPATH)=" >> /etc/environment
+if [ -z "$GAKKO_CHROME_DRIVER_PATH" ]; then
+  if command -v chromedriver >/dev/null 2>&1; then
+    export GAKKO_CHROME_DRIVER_PATH="$(command -v chromedriver)"
+  fi
+fi
+
+printenv | grep -E "^(GAKKO_USERNAME|GAKKO_PASSWORD|GAKKO_CLIENT_ID|GAKKO_CHROME_BINARY_PATH|GAKKO_CHROME_DRIVER_PATH|PYTHONPATH)=" >> /etc/environment
 
 cat <<EOF > /etc/cron.d/gakko-sync
 SHELL=/bin/bash

--- a/src/core/command_context.py
+++ b/src/core/command_context.py
@@ -3,6 +3,7 @@ from typing import List
 
 from selenium.webdriver import Chrome
 from selenium.webdriver.chrome.options import Options as ChromeOptions
+from selenium.webdriver.chrome.service import Service as ChromeService
 from selenium.webdriver.remote.webdriver import WebDriver
 
 from src.core.config import GakkoConfig
@@ -18,7 +19,8 @@ def _create_driver_from_config(config: GakkoConfig) -> WebDriver:
     options.add_argument("--disable-gpu")
     if config.chrome_binary_path:
         options.binary_location = config.chrome_binary_path
-    driver = Chrome(options=options)
+    service = ChromeService(executable_path=config.chrome_driver_path) if config.chrome_driver_path else None
+    driver = Chrome(options=options, service=service)
     driver.implicitly_wait(config.selenium_implicit_wait)
     driver.set_page_load_timeout(config.selenium_page_load_timeout)
     return driver

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -16,6 +16,7 @@ class GakkoConfig(BaseSettings):
 
     chrome_headless: bool = True
     chrome_binary_path: Optional[str] = None
+    chrome_driver_path: Optional[str] = None
     selenium_implicit_wait: int = 10
     selenium_page_load_timeout: int = 30
     selenium_element_wait: int = 10

--- a/tests/core/test_command_context.py
+++ b/tests/core/test_command_context.py
@@ -87,3 +87,21 @@ def test_create_driver_from_config_with_binary_path():
 
     options = mock_chrome_cls.call_args[1]["options"]
     assert options.binary_location == "/usr/bin/chromium"
+
+
+def test_create_driver_from_config_with_driver_path():
+    config = GakkoConfig(
+        base_url=HttpUrl("https://test.local"),
+        chrome_binary_path="/usr/bin/chromium",
+        chrome_driver_path="/usr/bin/chromedriver",
+    )
+
+    with patch("src.core.command_context.Chrome") as mock_chrome_cls:
+        mock_chrome_cls.return_value = MagicMock()
+
+        from src.core.command_context import _create_driver_from_config
+
+        _create_driver_from_config(config)
+
+    service = mock_chrome_cls.call_args[1]["service"]
+    assert service.path == "/usr/bin/chromedriver"


### PR DESCRIPTION
## Summary
- Install `chromium-driver` alongside `chromium` on arm64 in Dockerfile
- Add `chrome_driver_path` config to bypass Selenium Manager (unsupported on linux/aarch64)
- Auto-detect chromedriver path in entrypoint.sh

## Test plan
- [x] All existing tests pass
- [ ] `docker exec gakko-sync bash -c "cd /app && uv run python src/main.py"` works on Pi